### PR TITLE
Enabling first volume creation on Puppet > 4

### DIFF
--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -56,11 +56,20 @@ define gluster::peer (
 
       # and we don't want to attach a server that is already a member
       # of the current pool
-      $peers = split($::gluster_peer_list, ',' )
-      if ! member($peers, $title) {
-        exec { "gluster peer probe ${title}":
-          command => "${binary} peer probe ${title}",
+      if $::gluster_peer_list != undef {
+        $peers = split($::gluster_peer_list, ',' )
+        if ! member($peers, $title) {
+          $already_in_pool = false
+        } else {
+          $already_in_pool = true
         }
+      } else {
+        $already_in_pool = false
+      }
+      if !$already_in_pool {
+        exec { "gluster peer probe ${title}":
+            command => "${binary} peer probe ${title}",
+          }
       }
     }
   }


### PR DESCRIPTION
Volume creation depends on the 'gluster_volume_list' Fact which is empty if no volume already exists in this pool. On Puppet > 4, an undefined Fact cannot be used in the split() function. There for the code should proceed if any two cases are met:
-They are no pre-existing columes in the pool
-None of the existing volumes contain the one defined in this resource.