### PR TITLE
Several minor issues corrected in volume.pp script

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -102,7 +102,7 @@ define gluster::volume (
   if $binary{
     # we need the Gluster binary to do anything!
 
-    if ! member( split( $::gluster_volume_list, ',' ), $title ) {
+    if ! member( split( "${::gluster_volume_list}", ',' ), $title ) {
       # this volume has not yet been created
 
       # before we can create it, we need to ensure that all the


### PR DESCRIPTION
but I corrected them in the same commit and am a bit lazy to refractor since they are minor:
1. line 113 is prone to an error if no volumes defined (function does not handle undef well)
2. type on line 182
3. all regsubst were throwing an error due to G being a variable. Casting as string resolves the issue
