### PR TITLE
Fix buggy computation of volume create arguments

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -96,7 +96,7 @@ define gluster::volume (
     $_force,
   ]
 
-  $args = join(delete($cmd_args, ''), ' ')
+  $args = join(delete_undef_values($cmd_args), ' ')
 
   $binary = $::gluster_binary
   if $binary{


### PR DESCRIPTION
Before, if e.g. `$stripe` was `false`, then `$_stripe` would be `undef` and so `$args` would start literally with `undef`. Also, the `delete` operation in the former stanza `$args = join(delete($cmd_args, ''), ' ')` is a kinda no-op anyways.