### PR TITLE
Updating Test Cases for YUM and RPM installation

### DIFF
--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -13,7 +13,7 @@ describe 'gluster::install', type: :class do
         it { should compile.with_all_deps }
         case facts[:osfamily]
         when 'Redhat'
-          it { should create_package('glusterfs') }
+          it { should create_package('glusterfs-server') }
           it { should create_package('glusterfs-fuse') }
           it { should create_class('gluster::repo').with(version: 'LATEST') }
         when 'Debian'
@@ -45,7 +45,7 @@ describe 'gluster::install', type: :class do
         end
         case facts[:osfamily]
         when 'Redhat'
-          it { should_not create_package('glusterfs') }
+          it { should_not create_package('glusterfs-server') }
         when 'Debian'
           it { should_not create_package('glusterfs-server') }
         end

--- a/spec/classes/repo_yum_spec.rb
+++ b/spec/classes/repo_yum_spec.rb
@@ -13,12 +13,11 @@ describe 'gluster::repo::yum', type: :class do
           it { should compile.with_all_deps }
           it 'installs' do
             should_not create_package('yum-plugin-priorities')
-            should create_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub')
             should create_yumrepo('glusterfs-x86_64').with(
               enabled: 1,
-              baseurl: "https://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/epel-#{facts[:operatingsystemmajrelease]}/x86_64/",
+              baseurl: "http://mirror.centos.org/centos/#{facts[:operatingsystemmajrelease]}/storage/#{facts[:architecture]}/gluster-3.8/",
               gpgcheck: 1,
-              gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub'
+              gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-#{facts[:operatingsystemmajrelease]}"
             )
           end
         end
@@ -30,7 +29,7 @@ describe 'gluster::repo::yum', type: :class do
           end
           it 'does not install' do
             expect do
-              should create_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub')
+              should create_file('/etc/yum.repos.d/glusterfs-x86_64.repo')
             end.to raise_error(Puppet::Error, %r{doesn't make sense!})
           end
         end
@@ -42,7 +41,7 @@ describe 'gluster::repo::yum', type: :class do
           end
           it 'does not install' do
             expect do
-              should create_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub')
+              should create_file('/etc/yum.repos.d/glusterfs-x86_64.repo')
             end.to raise_error(Puppet::Error, %r{not yet supported})
           end
         end
@@ -53,13 +52,12 @@ describe 'gluster::repo::yum', type: :class do
             }
           end
           it 'installs' do
-            should create_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub')
             should create_package('yum-plugin-priorities')
             should create_yumrepo('glusterfs-x86_64').with(
               enabled: 1,
-              baseurl: "https://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/epel-#{facts[:operatingsystemmajrelease]}/x86_64/",
+              baseurl: "http://mirror.centos.org/centos/#{facts[:operatingsystemmajrelease]}/storage/#{facts[:architecture]}/gluster-3.8/",
               gpgcheck: 1,
-              gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-gluster.pub',
+              gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-#{facts[:operatingsystemmajrelease]}"
               priority: '50'
             )
           end

--- a/spec/classes/repo_yum_spec.rb
+++ b/spec/classes/repo_yum_spec.rb
@@ -57,7 +57,7 @@ describe 'gluster::repo::yum', type: :class do
               enabled: 1,
               baseurl: "http://mirror.centos.org/centos/#{facts[:operatingsystemmajrelease]}/storage/#{facts[:architecture]}/gluster-3.8/",
               gpgcheck: 1,
-              gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-#{facts[:operatingsystemmajrelease]}"
+              gpgkey: "http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-#{facts[:operatingsystemmajrelease]}",
               priority: '50'
             )
           end


### PR DESCRIPTION
As per #76, updated YUM repo url, key source and server rpm name for new CentOS YUM repo.
Note: version 3.8 had to be hard coded in the repo URL in the test since the new CentOS repo doesn't have a 'LATEST' folder.