### PR TITLE
Make use of defined() to check for the existence of Fact

### DIFF
--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -56,7 +56,7 @@ define gluster::peer (
 
       # and we don't want to attach a server that is already a member
       # of the current pool
-      if $::gluster_peer_list != undef {
+      if defined('$::gluster_peer_list') {
         $peers = split($::gluster_peer_list, ',' )
         if ! member($peers, $title) {
           $already_in_pool = false

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -103,13 +103,13 @@ define gluster::volume (
   if $binary{
     # we need the Gluster binary to do anything!
 
-    if $::gluster_peer_list != undef{
+    if defined('$::gluster_peer_list') {
       $minimal_requirements = true
     } else {
       $minimal_requirements = false
     }
 
-    if $::gluster_volume_list != undef and member( split( $::gluster_volume_list, ',' ), $title ) {
+    if defined('$::gluster_volume_list') and member( split( $::gluster_volume_list, ',' ), $title ) {
       $already_exists = true
     } else {
       $already_exists = false


### PR DESCRIPTION
As pointed out in #82, the Puppet parser using strict variable check will throw an error when check if a Fact not yet initialized is Undef.
Using the defined() function to lookup the existence of the Fact should work on all version and type of parser.