### PR TITLE
Comparing expected volume bricks against actual should not depend on order

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -177,8 +177,8 @@ define gluster::volume (
       # this volume exists
 
       # our fact lists bricks comma-separated, but we need an array
-      $vol_bricks = split( getvar( "::gluster_volume_${title}_bricks" ), ',')
-      if $bricks != $vol_bricks {
+      $vol_bricks = sort(any2array(split( getvar( "::gluster_volume_${title}_bricks" ), ',')))
+      if sort($bricks) != $vol_bricks {
         # this resource's list of bricks does not match the existing
         # volume's list of bricks
         $new_bricks = difference($bricks, $vol_bricks)


### PR DESCRIPTION
Hello,

When creating a volume, existing volume bricks are checked against actual ones.
Problem happens when volume as found from facter is not in the same order as those defined in puppet. Final result is a notice stating that "Notice: unable to resolve brick changes for Gluster volume owncloud!".

This simple PR just changes brick comparison so that it no longer relies on brick order.

Cheers !