### PR TITLE
Allow passing no replication count

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -73,6 +73,8 @@ define gluster::volume (
     } else {
       $_replica = "replica ${replica}"
     }
+  } else {
+    $_replica = ''
   }
 
   if ! member( ['tcp', 'rdma', 'tcp,rdma'], $transport ) {

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -42,6 +42,23 @@ describe 'gluster::volume', type: :define do
       it { is_expected.to compile }
     end
 
+    describe 'with replica count' do
+      let(:title) { 'storage1' }
+      let(:facts) {
+          {
+              gluster_binary: '/usr/bin/gluster',
+              gluster_peer_list: 'srv1.local,srv2.local',
+              gluster_volume_list: 'storage2',
+          }
+      }
+
+      it do
+          is_expected.to compile
+          is_expected.to contain_exec('gluster create volume storage1') \
+              .with_command(/replica [\d]+/)
+      end
+    end
+
     describe 'no replica count' do
       let(:title) { 'storage1' }
       let(:params) {

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -42,6 +42,39 @@ describe 'gluster::volume', type: :define do
       it { is_expected.to compile }
     end
 
+    describe 'no replica count' do
+      let(:title) { 'storage1' }
+      let(:params) {
+        {
+          replica: false,
+          bricks: [
+            'srv1.local:/export/brick1/brick',
+            'srv2.local:/export/brick1/brick',
+            'srv1.local:/export/brick2/brick',
+            'srv2.local:/export/brick2/brick'
+          ],
+          options: [
+            'server.allow-insecure: on',
+            'nfs.ports-insecure: on'
+          ]
+        }
+      }
+
+      let(:facts) {
+          {
+              gluster_binary: '/usr/bin/gluster',
+              gluster_peer_list: 'srv1.local,srv2.local',
+              gluster_volume_list: 'storage2',
+          }
+      }
+
+      it do
+          is_expected.to compile
+          is_expected.to contain_exec('gluster create volume storage1') \
+              .without_command(/replica [\d]+/)
+      end
+    end
+
     describe 'with all facts' do
       let(:facts) do
         {


### PR DESCRIPTION
Fixes compilation failure on missing replica count.
Adds test for both cases (missing and passed).

Resolves #92 .

Please have a critical look - I haven't written much ruby yet, not to say from ruby spec tests and the tests I'm seeing here and on the rspec-puppet pages are quite different (which I guess is either the usualy ruby-weirdness of doing the same thing in five different ways or that the tests have been written with different best practes).
