### PR TITLE
add rudimentary multihoming support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class gluster  (
   $server_package         = $::gluster::params::server_package,
   $use_exported_resources = $::gluster::params::export_resources,
   $version                = $::gluster::params::version,
+  $identity               = $::gluster::params::identity,
   $volumes                = undef,
 ) inherits ::gluster::params {
 
@@ -71,7 +72,7 @@ class gluster  (
 
     if $use_exported_resources {
       # first we export this server's instance
-      @@gluster::peer { $::fqdn:
+      @@gluster::peer { $identity:
         pool => $pool,
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,6 +80,9 @@ class gluster::params {
   $pool = 'default'
   $export_resources = true
 
+  # this is how we identify ourselfes in case of multihome
+  $identity = $::fqdn
+
   # parameters dealing with bricks
 
   # parameters dealing with volumes

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -51,7 +51,7 @@ define gluster::peer (
   if getvar('::gluster_binary') {
     # we can't join to ourselves, so it only makes sense to operate
     # on other gluster servers in the same pool
-    include gluster::params
+    include ::gluster::params
     if $title != $gluster::params::identity {
 
       # and we don't want to attach a server that is already a member

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -4,7 +4,7 @@
 # a Gluster Trusted Storage Pool. Each server should also collect all
 # such exported resources for local realization.
 #
-# If the title of the exported resource is NOT the FQDN of the host
+# If the title of the exported resource is NOT our own identity
 # on which the resource is being realized, then try to initiate a
 # Gluster peering relationship.
 #
@@ -51,7 +51,8 @@ define gluster::peer (
   if getvar('::gluster_binary') {
     # we can't join to ourselves, so it only makes sense to operate
     # on other gluster servers in the same pool
-    if $title != $::fqdn {
+    include gluster::params
+    if $title != $gluster::params::identity {
 
       # and we don't want to attach a server that is already a member
       # of the current pool

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -49,6 +49,7 @@ define gluster::volume (
   $bricks         = undef,
   $options        = undef,
   $remove_options = false,
+  $identity       = $gluster::params::identity,
 ) {
 
   # basic sanity checking
@@ -123,7 +124,7 @@ define gluster::volume (
       # first, get a list of unique server names hosting bricks
       $brick_hosts = unique( regsubst( $bricks, '^([^:]+):(.+)$', '\1') )
       # now get a list of all peers, including ourself
-      $pool_members = concat( split( $::gluster_peer_list, ','), [ $::fqdn ] )
+      $pool_members = concat( split( $::gluster_peer_list, ','), [ $identity ] )
       # now see what the difference is
       $missing_bricks = difference( $brick_hosts, $pool_members)
 


### PR DESCRIPTION
In a multi-homed setup, a node might not offer GlusterFS services
on the interface associated with it's FQDN, but e.g. on a service
interface. To handle that case, this commit adds an `identity`
parameter.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
