### PR TITLE
pass 'release' attribute to sub classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class gluster  (
     server_package => $server_package,
     client         => $client,
     client_package => $client_package,
+    release        => $release,
     version        => $version,
     repo           => $repo,
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,17 +32,16 @@ class gluster::install (
   Boolean $server        = $gluster::params::install_server,
   Boolean $client        = $gluster::params::install_client,
   Boolean $repo          = $gluster::params::repo,
+  String $release        = $gluster::params::release,
   String $version        = $gluster::params::version,
   String $server_package = $gluster::params::server_package,
   String $client_package = $gluster::params::client_package,
 ) inherits ::gluster::params {
 
   if $repo {
-    # install the correct repo
-    if ! defined ( Class[::gluster::repo] ) {
-      class { '::gluster::repo':
-        version => $version,
-      }
+    class { '::gluster::repo':
+      release => $release,
+      version => $version,
     }
   }
 


### PR DESCRIPTION
prior to this this commit 'release' atribute from 'main' class wasn't passed to sub-classes
construct '! defined Class' provides random results, parser dependable and shouldn't be used


