### PR TITLE
Fix/types: Fix signature of gluster::volume

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -40,7 +40,7 @@
 # Copyright 2014 CoverMyMeds, unless otherwise noted
 #
 define gluster::volume (
-  Array $bricks,
+  Array[String, 1] $bricks,
 
   Boolean $force                              = false,
   Enum['tcp', 'rdma', 'tcp,rdma'] $transport  = 'tcp',

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -40,11 +40,12 @@
 # Copyright 2014 CoverMyMeds, unless otherwise noted
 #
 define gluster::volume (
+  Array $bricks,
+
   Boolean $force                              = false,
   Enum['tcp', 'rdma', 'tcp,rdma'] $transport  = 'tcp',
   Boolean $rebalance                          = true,
   Boolean $heal                               = true,
-  Array $bricks                               = undef,
   Boolean $remove_options                     = false,
   Optional[Array] $options                    = undef,
   Optional[Integer] $stripe                   = undef,

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -48,7 +48,7 @@ define gluster::volume (
   Boolean $remove_options                     = false,
   Optional[Array] $options                    = undef,
   Optional[Integer] $stripe                   = undef,
-  Optional[Integer] $replica                  = false,
+  Optional[Integer] $replica                  = undef,
 ) {
 
   if $force {


### PR DESCRIPTION
Type `Optional[Integer]` can only hold integers and `undef`, not `false`. Produces compilation error.

Parameter `Array $bricks` is non-optional, hence no default should be set. The set default cannot be hold by `Array` either and produces compilation errors with misleading error messages.