### PR TITLE
Including other names in the preer probe fact

### DIFF
--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -29,6 +29,10 @@ if binary
   peer_count = Regexp.last_match[1].to_i if output =~ %r{^Number of Peers: (\d+)$}
   if peer_count > 0
     peer_list = output.scan(%r{^Hostname: (.+)$}).flatten.join(',')
+    other_names = output.scan(%r{^Other names:\n((.+\n)+)}).flatten.join.scan(%r{(.+)\n?}).sort.uniq.flatten.join(',')
+    if other_names
+      peer_list += ',' +  other_names
+    end
     # note the stderr redirection here
     # `gluster volume list` spits to stderr :(
     output = Facter::Util::Resolution.exec("#{binary} volume list 2>&1")


### PR DESCRIPTION
When having multiple interfaces on a gluster cluster.
It is now possible to probe each interface and facter will return the
other names as well.
Otherwise fater will probe each run

Fixes #124
