### PR TITLE
Fixed logic for single node gluster servers

### DIFF
--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -29,6 +29,10 @@ if binary
   peer_count = Regexp.last_match[1].to_i if output =~ %r{^Number of Peers: (\d+)$}
   if peer_count > 0
     peer_list = output.scan(%r{^Hostname: (.+)$}).flatten.join(',')
+    other_names = output.scan(%r{^Other names:\n((.+\n)+)}).flatten.join.scan(%r{(.+)\n?}).sort.uniq.flatten.join(',')
+    if other_names
+      peer_list += ',' +  other_names
+    end
     # note the stderr redirection here
     # `gluster volume list` spits to stderr :(
     output = Facter::Util::Resolution.exec("#{binary} volume list 2>&1")

--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -30,9 +30,7 @@ if binary
   if peer_count > 0
     peer_list = output.scan(%r{^Hostname: (.+)$}).flatten.join(',')
     other_names = output.scan(%r{^Other names:\n((.+\n)+)}).flatten.join.scan(%r{(.+)\n?}).sort.uniq.flatten.join(',')
-    if other_names
-      peer_list += ',' +  other_names
-    end
+    peer_list += ',' + other_names if other_names
   end
   # note the stderr redirection here
   # `gluster volume list` spits to stderr :(
@@ -41,7 +39,6 @@ if binary
     output.split.each do |vol|
       # If a brick has trailing informaion such as (arbiter) remove it
       info = Facter::Util::Resolution.exec("#{binary} volume info #{vol} | sed 's/ (arbiter)//g'")
-      # rubocop:disable Metrics/BlockNesting
       vol_status = Regexp.last_match[1] if info =~ %r{^Status: (.+)$}
       bricks = info.scan(%r{^Brick[^:]+: (.+)$}).flatten
       volume_bricks[vol] = bricks

--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -33,24 +33,24 @@ if binary
     if other_names
       peer_list += ',' +  other_names
     end
-    # note the stderr redirection here
-    # `gluster volume list` spits to stderr :(
-    output = Facter::Util::Resolution.exec("#{binary} volume list 2>&1")
-    if output != 'No volumes present in cluster'
-      output.split.each do |vol|
-        # If a brick has trailing informaion such as (arbiter) remove it
-        info = Facter::Util::Resolution.exec("#{binary} volume info #{vol} | sed 's/ (arbiter)//g'")
-        # rubocop:disable Metrics/BlockNesting
-        vol_status = Regexp.last_match[1] if info =~ %r{^Status: (.+)$}
-        bricks = info.scan(%r{^Brick[^:]+: (.+)$}).flatten
-        volume_bricks[vol] = bricks
-        options = info.scan(%r{^(\w+\.[^:]+: .+)$}).flatten
-        volume_options[vol] = options if options
-        next unless vol_status == 'Started'
-        status = Facter::Util::Resolution.exec("#{binary} volume status #{vol} 2>/dev/null")
-        if status =~ %r{^Brick}
-          volume_ports[vol] = status.scan(%r{^Brick [^\t]+\t+(\d+)}).flatten.uniq.sort
-        end
+  end
+  # note the stderr redirection here
+  # `gluster volume list` spits to stderr :(
+  output = Facter::Util::Resolution.exec("#{binary} volume list 2>&1")
+  if output != 'No volumes present in cluster'
+    output.split.each do |vol|
+      # If a brick has trailing informaion such as (arbiter) remove it
+      info = Facter::Util::Resolution.exec("#{binary} volume info #{vol} | sed 's/ (arbiter)//g'")
+      # rubocop:disable Metrics/BlockNesting
+      vol_status = Regexp.last_match[1] if info =~ %r{^Status: (.+)$}
+      bricks = info.scan(%r{^Brick[^:]+: (.+)$}).flatten
+      volume_bricks[vol] = bricks
+      options = info.scan(%r{^(\w+\.[^:]+: .+)$}).flatten
+      volume_options[vol] = options if options
+      next unless vol_status == 'Started'
+      status = Facter::Util::Resolution.exec("#{binary} volume status #{vol} 2>/dev/null")
+      if status =~ %r{^Brick}
+        volume_ports[vol] = status.scan(%r{^Brick [^\t]+\t+(\d+)}).flatten.uniq.sort
       end
     end
   end
@@ -62,42 +62,39 @@ if binary
     end
   end
 
-  # these facts doesn't make sense without peers
-  if peer_count > 0
-    Facter.add(:gluster_peer_list) do
+  Facter.add(:gluster_peer_list) do
+    setcode do
+      peer_list
+    end
+  end
+
+  unless volume_bricks.empty?
+    Facter.add(:gluster_volume_list) do
       setcode do
-        peer_list
+        volume_bricks.keys.join(',')
       end
     end
-
-    unless volume_bricks.empty?
-      Facter.add(:gluster_volume_list) do
+    volume_bricks.each do |vol, bricks|
+      Facter.add("gluster_volume_#{vol}_bricks".to_sym) do
         setcode do
-          volume_bricks.keys.join(',')
+          bricks.join(',')
         end
       end
-      volume_bricks.each do |vol, bricks|
-        Facter.add("gluster_volume_#{vol}_bricks".to_sym) do
+    end
+    if volume_options
+      volume_options.each do |vol, opts|
+        Facter.add("gluster_volume_#{vol}_options".to_sym) do
           setcode do
-            bricks.join(',')
+            opts.join(',')
           end
         end
       end
-      if volume_options
-        volume_options.each do |vol, opts|
-          Facter.add("gluster_volume_#{vol}_options".to_sym) do
-            setcode do
-              opts.join(',')
-            end
-          end
-        end
-      end
-      if volume_ports
-        volume_ports.each do |vol, ports|
-          Facter.add("gluster_volume_#{vol}_ports".to_sym) do
-            setcode do
-              ports.join(',')
-            end
+    end
+    if volume_ports
+      volume_ports.each do |vol, ports|
+        Facter.add("gluster_volume_#{vol}_ports".to_sym) do
+          setcode do
+            ports.join(',')
           end
         end
       end

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -42,7 +42,8 @@
 #       peering attempt only resolves a cosmetic issue, not a functional one.
 #
 define gluster::peer (
-  $pool = 'default'
+  $pool = 'default',
+  $fqdn = $::fqdn,
 ) {
 
   # we can't do much without the Gluster binary
@@ -51,7 +52,7 @@ define gluster::peer (
   if getvar('::gluster_binary') {
     # we can't join to ourselves, so it only makes sense to operate
     # on other gluster servers in the same pool
-    if $title != $::fqdn {
+    if $fqdn != $::fqdn {
 
       # and we don't want to attach a server that is already a member
       # of the current pool

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -117,60 +117,46 @@ define gluster::volume (
     if $minimal_requirements and $already_exists == false {
       # this volume has not yet been created
 
-      # before we can create it, we need to ensure that all the
-      # servers hosting bricks are members of the storage pool
+      exec { "gluster create volume ${title}":
+        command => "${::gluster_binary} volume create ${title} ${args}",
+      }
+
+      # if we have volume options, activate them now
       #
-      # first, get a list of unique server names hosting bricks
-      $brick_hosts = unique( regsubst( $bricks, '^([^:]+):(.+)$', '\1') )
-      # now get a list of all peers, including ourself
-      $pool_members = concat( split( $::gluster_peer_list, ','), [ $::fqdn ] )
-      # now see what the difference is
-      $missing_bricks = difference( $brick_hosts, $pool_members)
+      # Note: $options is an array, but create_resources requires
+      #       a hash of hashes.  We do some contortions to get the
+      #       array into the hash of hashes that looks like:
+      #
+      #       option.name:
+      #         value: value
+      #
+      # Note 2: we're using the $_options variable, which contains the
+      #         sorted list of options.
+      if $_options {
+        # first we need to prefix each array element with the volume name
+        # so that we match the gluster::volume::option title format of
+        #  volume:option
+        $vol_opts = prefix( $_options, "${title}:" )
+        # now we make some YAML, and then parse that to get a Puppet hash
+        $yaml = join( regsubst( $vol_opts, ': ', ":\n  value: ", 'G'), "\n")
+        $hoh = parseyaml($yaml)
 
-      if ! empty($missing_bricks) {
-        notice("Not creating Gluster volume ${title}: some bricks are not in the pool")
-      } else {
-        exec { "gluster create volume ${title}":
-          command => "${::gluster_binary} volume create ${title} ${args}",
-        }
-
-        # if we have volume options, activate them now
-        #
-        # Note: $options is an array, but create_resources requires
-        #       a hash of hashes.  We do some contortions to get the
-        #       array into the hash of hashes that looks like:
-        #
-        #       option.name:
-        #         value: value
-        #
-        # Note 2: we're using the $_options variable, which contains the
-        #         sorted list of options.
-        if $_options {
-          # first we need to prefix each array element with the volume name
-          # so that we match the gluster::volume::option title format of
-          #  volume:option
-          $vol_opts = prefix( $_options, "${title}:" )
-          # now we make some YAML, and then parse that to get a Puppet hash
-          $yaml = join( regsubst( $vol_opts, ': ', ":\n  value: ", 'G'), "\n")
-          $hoh = parseyaml($yaml)
-
-          # safety check
-          assert_type(Hash, $hoh)
-          # we need to ensure that these are applied AFTER the volume is created
-          # but BEFORE the volume is started
-          $new_volume_defaults = {
-            require => Exec["gluster create volume ${title}"],
-            before  => Exec["gluster start volume ${title}"],
-          }
-
-          create_resources(::gluster::volume::option, $hoh, $new_volume_defaults)
-        }
-
-        # don't forget to start the new volume!
-        exec { "gluster start volume ${title}":
-          command => "${::gluster_binary} volume start ${title}",
+        # safety check
+        assert_type(Hash, $hoh)
+        # we need to ensure that these are applied AFTER the volume is created
+        # but BEFORE the volume is started
+        $new_volume_defaults = {
           require => Exec["gluster create volume ${title}"],
+          before  => Exec["gluster start volume ${title}"],
         }
+
+        create_resources(::gluster::volume::option, $hoh, $new_volume_defaults)
+      }
+
+      # don't forget to start the new volume!
+      exec { "gluster start volume ${title}":
+        command => "${::gluster_binary} volume start ${title}",
+        require => Exec["gluster create volume ${title}"],
       }
 
     } elsif $already_exists {

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -102,19 +102,13 @@ define gluster::volume (
   if getvar('::gluster_binary'){
     # we need the Gluster binary to do anything!
 
-    if getvar('::gluster_peer_list') {
-      $minimal_requirements = true
-    } else {
-      $minimal_requirements = false
-    }
-
     if getvar('::gluster_volume_list') and member( split( $::gluster_volume_list, ',' ), $title ) {
       $already_exists = true
     } else {
       $already_exists = false
     }
 
-    if $minimal_requirements and $already_exists == false {
+    if $already_exists == false {
       # this volume has not yet been created
 
       exec { "gluster create volume ${title}":

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe 'gluster::peer', type: :define do
   let(:title) { 'peer1.example.com' }
 
+  let(:params) do
+    {
+      fqdn: 'peer1.example.com'
+    }
+  end
+
   describe 'missing gluster_binary fact' do
     it { is_expected.to compile }
     it { is_expected.not_to contain_exec('gluster peer probe peer1.example.com') }
@@ -51,7 +57,8 @@ describe 'gluster::peer', type: :define do
         {
           gluster_binary: '/usr/sbin/gluster',
           gluster_peer_count: 0,
-          gluster_peer_list: ''
+          gluster_peer_list: '',
+          fqdn: 'peer99.example.com'
         }
       end
 
@@ -63,7 +70,8 @@ describe 'gluster::peer', type: :define do
         {
           gluster_binary: '/usr/sbin/gluster',
           gluster_peer_count: 1,
-          gluster_peer_list: 'peer2.example.com'
+          gluster_peer_list: 'peer2.example',
+          fqdn: 'peer99.example.com'
         }
       end
 
@@ -75,7 +83,8 @@ describe 'gluster::peer', type: :define do
         {
           gluster_binary: '/usr/sbin/gluster',
           gluster_peer_count: 2,
-          gluster_peer_list: 'peer2.example.com,peer3.example.com'
+          gluster_peer_list: 'peer2.example,peer3.example',
+          fqdn: 'peer99.example.com'
         }
       end
 
@@ -84,7 +93,7 @@ describe 'gluster::peer', type: :define do
     end
   end
 
-  describe 'self joining (fqdn matches resource title)' do
+  describe 'self joining' do
     let(:facts) do
       {
         gluster_binary: '/usr/sbin/gluster',
@@ -98,5 +107,20 @@ describe 'gluster::peer', type: :define do
     it 'we don\'t try to join with ourselves' do
       is_expected.not_to contain_exec('gluster peer probe peer1.example.com')
     end
+  end
+
+  describe 'use custom host name (not fqdn)' do
+    let(:title) { 'peer1.example' }
+    let(:facts) do
+      {
+        gluster_binary: '/usr/sbin/gluster',
+        gluster_peer_count: 0,
+        gluster_peer_list: '',
+        fqdn: 'peer99.example.com'
+      }
+    end
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_exec('gluster peer probe peer1.example') }
   end
 end

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -94,4 +94,17 @@ describe 'gluster::volume', type: :define do
       end
     end
   end
+
+  describe 'single node' do
+    let(:facts) do
+      {
+        gluster_binary: '/usr/sbin/gluster',
+        gluster_peer_count: 0,
+        gluster_peer_list: ''
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec("gluster create volume #{title}") }
+  end
 end


### PR DESCRIPTION
When trying to configure Gluster on single node no `gluster::volume` exec's were applied, no volume created, etc.

This behavior was created by assumptions on `gluster_peer_count` and `gluster_peer_list` facts as it is empty when operating on single node.
Second thing was that check for missing bricks (in `gluster::volume`) always failed because of empty `gluster_peer_list` - no peers, no volumes :). Fortunately there already was https://github.com/voxpupuli/puppet-gluster/pull/125 which seemed as good fit. Since it worked, It's now merged into this PR.

Fixes https://github.com/voxpupuli/puppet-gluster/issues/6 , but since that time behaviour has changed a little - no duplicates, just nothing :).
