### PR TITLE
make the code compatible with strict_variables

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -52,22 +52,32 @@ define gluster::mount (
 
   if $log_level {
     $ll = "log-level=${log_level}"
+  } else {
+    $ll = undef
   }
 
   if $log_file {
     $lf = "log-file=${log_file}"
+  } else {
+    $lf = undef
   }
 
   if $transport {
     $t = "transport=${transport}"
+  } else {
+    $t = undef
   }
 
   if $direct_io_mode {
     $dim = "direct-io-mode=${direct_io_mode}"
+  } else {
+    $dim = undef
   }
 
   if $readdirp {
     $r = "usereaddrip=${readdirp}"
+  } else {
+    $r = undef
   }
 
   $mount_options = [ $options, $ll, $lf, $t, $dim, $r, ]

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -66,12 +66,16 @@ define gluster::volume (
 
   if $replica {
     $_replica = "replica ${replica}"
+  } else {
+    $_replica = undef
   }
 
   $_transport = "transport ${transport}"
 
   if $options {
     $_options = sort( $options )
+  } else {
+    $_options = undef
   }
 
   $_bricks = join( $bricks, ' ' )


### PR DESCRIPTION
This PR ensures that all referenced variables are assigned to first, and make the module compatible with Puppet running with `strict_variables=true`.