### PR TITLE
drop debian 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ matrix:
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.4.0
     bundler_args: --without development
-    env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/debian-8" bundle exec rake acceptance
-    services: docker
-    sudo: required
-  - rvm: 2.4.0
-    bundler_args: --without development
     env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/centos-7" bundle exec rake acceptance
     services: docker
     sudo: required

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This class handles the installation of the Gluster packages (both server and cli
 
 If the upstream Gluster repo is enabled (default), this class will install packages from there. Otherwise it will attempt to use native OS packages.
 
-Currently, RHEL 6, RHEL 7, Debian 8, Raspbian and Ubuntu provide native Gluster packages (at least client).
+Currently, RHEL 6, RHEL 7, Debian 9, Raspbian and Ubuntu provide native Gluster packages (at least client).
 
     class { gluster::install:
       server  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9"
       ]
     },


### PR DESCRIPTION
Acceptance tests proved that debian 8 wasn't correctly working. Is it still a major release if we officially drop it? I guess so.