### PR TITLE
bump default gluster version 3.8->3.12

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class gluster::params {
   # parameters dealing with installation
   $install_server = true
   $install_client = true
-  $release        = '3.8'
+  $release        = '3.12'
   $version        = 'LATEST'
 
   # we explicitly do NOT set a priority here. The user must define


### PR DESCRIPTION
3.8 is EOL, 3.12 is the latest available version

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
