### PR TITLE
fix argument passing of arbiter option

### DIFF
--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -34,7 +34,8 @@ if binary
     output = Facter::Util::Resolution.exec("#{binary} volume list 2>&1")
     if output != 'No volumes present in cluster'
       output.split.each do |vol|
-        info = Facter::Util::Resolution.exec("#{binary} volume info #{vol}")
+        # If a brick has trailing informaion such as (arbiter) remove it
+        info = Facter::Util::Resolution.exec("#{binary} volume info #{vol} | sed 's/ (arbiter)//g'")
         # rubocop:disable Metrics/BlockNesting
         vol_status = Regexp.last_match[1] if info =~ %r{^Status: (.+)$}
         bricks = info.scan(%r{^Brick[^:]+: (.+)$}).flatten

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -80,11 +80,18 @@ define gluster::volume (
     $_options = undef
   }
 
+  if $arbiter {
+    $_arbiter = "arbiter ${arbiter}"
+  } else {
+    $_arbiter = ''
+  }
+
   $_bricks = join( $bricks, ' ' )
 
   $cmd_args = [
     $_stripe,
     $_replica,
+    $_arbiter,
     $_transport,
     $_bricks,
     $_force,


### PR DESCRIPTION
Fix the passing of the optional `arbiter` parameter to the volume class.

This fixes an issue where the arbiter value could be incorrectly not be set upon volume creation.

Fixes #151 