### PR TITLE
Drop Debian 8 acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,11 +2,6 @@
 .travis.yml:
   extras:
   - rvm: 2.4.0
-    env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/debian-8" bundle exec rake acceptance
-    services: docker
-    sudo: required
-    bundler_args: --without development
-  - rvm: 2.4.0
     env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/centos-7" bundle exec rake acceptance
     services: docker
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ matrix:
     env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.4.0
     bundler_args: --without development
-    env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/debian-8" bundle exec rake acceptance
-    services: docker
-    sudo: required
-  - rvm: 2.4.0
-    bundler_args: --without development
     env: PUPPET_VERSION="~> 4.0" CHECK=acceptance BEAKER_set="docker/centos-7" bundle exec rake acceptance
     services: docker
     sudo: required


### PR DESCRIPTION
Debian 8 (Jessie) acceptance tests have been broken for some time. Drop testing from the matrix while a decision is being made as to how to re-include them so they work, or drop Debian 8 support in this module permanently.

See #139 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
