### PR TITLE
Fix arbiter doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This defined type creates a Gluster volume. You can specify a stripe count, a re
 
 Note that creating brick filesystems is up to you. May I recommend the [Puppet Labs LVM module](https://forge.puppetlabs.com/puppetlabs/lvm) ?
 
-If using [arbiter](https://gluster.readthedocs.io/en/latest/Administrator%20Guide/arbiter-volumes-and-quorum/) volumes, you must conform to the replica count that will work with them, at the time of writing this, Gluster 3.12 only supports a configuration of `replica => 2, arbiter => 1`.
+If using [arbiter](https://gluster.readthedocs.io/en/latest/Administrator%20Guide/arbiter-volumes-and-quorum/) volumes, you must conform to the replica count that will work with them, at the time of writing this, Gluster 3.12 only supports a configuration of `replica => 3, arbiter => 1`.
 
 When creating a new volume, this defined type will ensure that all of the servers hosting bricks in the volume are members of the storage pool. In this way, you can define the volume at the time you create servers, and once the last peer joins the pool the volume will be created.
 


### PR DESCRIPTION
#### Pull Request (PR) description

Current README statement about arbiter is wrong, if you follow instructions the result is
~~~
Notice: /Stage[main]/Gluster/Gluster::Volume[g0]/Exec[gluster create volume g0]/returns: For arbiter configuration, replica count must be 3 and arbiter count must be 1. The 3rd brick of the replica will be the arbiter
Notice: /Stage[main]/Gluster/Gluster::Volume[g0]/Exec[gluster create volume g0]/returns: 
Notice: /Stage[main]/Gluster/Gluster::Volume[g0]/Exec[gluster create volume g0]/returns: Usage:
Notice: /Stage[main]/Gluster/Gluster::Volume[g0]/Exec[gluster create volume g0]/returns: volume create <NEW-VOLNAME> [stripe <COUNT>] [replica <COUNT> [arbiter <COUNT>]] [disperse [<COUNT>]] [disperse-data <COUNT>] [redundancy <COUNT>] [transport <tcp|rdma|tcp,rdma>] <NEW-BRICK>?<vg_name>... [force]
~~~