### PR TITLE
Allow double digit minor and build versions

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -58,9 +58,9 @@ class gluster::repo::apt (
   if $version == 'LATEST' {
     $repo_ver = $version
   } else {
-    if $version =~ /^\d\.\d$/ {
+    if $version =~ /^\d\.\d+$/ {
       $repo_ver = "${version}/LATEST"
-    } elsif $version =~ /^(\d)\.(\d)\.(\d).*$/ {
+    } elsif $version =~ /^(\d)\.(\d+)\.(\d+).*$/ {
       $repo_ver =  "${1}.${2}/${1}.${2}.${3}"
     } else {
       fail("${version} doesn't make sense for ${::operatingsystem}!")


### PR DESCRIPTION
When providing the version to install if a double digit minor or build number is provided (ie, 3.12) the module will fail reporting that the version doesn't make sense. This patch corrects this.

Fixes #162 