### PR TITLE
use simple quotes for Class names to comply with lint

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,7 +39,7 @@ class gluster::install (
 
   if $repo {
     # install the correct repo
-    if ! defined ( Class[::gluster::repo] ) {
+    if ! defined ( Class['::gluster::repo'] ) {
       class { '::gluster::repo':
         version => $version,
       }
@@ -59,7 +59,7 @@ class gluster::install (
       ensure_packages($server_package, {
         ensure => $_version,
         tag    => 'gluster-packages',
-        notify => Class[::gluster::service],
+        notify => Class['::gluster::service'],
       })
     } elsif $client {
       ensure_packages($client_package, {
@@ -80,7 +80,7 @@ class gluster::install (
       # we use ensure_packages here because on some distributions the client and server package have different names
       ensure_packages($server_package, {
         ensure => $_version,
-        notify => Class[::gluster::service],
+        notify => Class['::gluster::service'],
         tag    => 'gluster-packages',
       })
     }


### PR DESCRIPTION
Using language-puppet to validate our puppet code, we came across a syntax issue with resource names that not quoted. 
As far as I understand, the resources names should follow the style documented here https://puppet.com/docs/puppet/4.10/style_guide.html#resource-names. 

If I'm mistaken, could you give an explanation of the coding style used here? 

Cheers,
Thomas

