### PR TITLE
Add Gluster APT Repo PGP fingerprints for 3.13, 4.0, 4.1 and 5+

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -45,6 +45,10 @@ class gluster::repo::apt (
     '3.10'                                    => 'C784DD0FD61E38B8B1F65E10DAD761554A72C1DF',
     '3.11'                                    => 'DE82F0BACC4DB70DBEF95CA65EC2255642304A6E',
     '3.12'                                    => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
+    '3.13'                                    => '9B5AE8E6FD2581F293104ACC38675E5F30F779AF',
+    '4.0'                                     => '55F839E173AC06F364120D46FA86EEACB306CEE1',
+    '4.1'                                     => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
+    '^5\.(\d)+$'                              => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
     default                                   => '849512C2CA648EF425048F55C883F50CB2289A17',
   }
 

--- a/spec/classes/repo_apt_spec.rb
+++ b/spec/classes/repo_apt_spec.rb
@@ -53,6 +53,26 @@ describe 'gluster::repo::apt', type: :class do
           end
         end
 
+        context 'Specific Gluster release 4.1' do
+          let :params do
+            {
+              release: '4.1'
+            }
+          end
+
+          it 'installs' do
+            is_expected.to contain_apt__source('glusterfs-LATEST').with(
+              repos: 'main',
+              release: facts[:lsbdistcodename].to_s,
+              key: {
+                'id' => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
+                'key_source' => 'https://download.gluster.org/pub/gluster/glusterfs/4.1/rsa.pub'
+              },
+              location: "http://download.gluster.org/pub/gluster/glusterfs/4.1/LATEST/Debian/#{facts[:lsbdistcodename]}/amd64/apt/"
+            )
+          end
+        end
+
         context 'Specific Gluster release 3.9' do
           let :params do
             {


### PR DESCRIPTION
Since I needed it for my project anyway, I thought I'd update the PGP fingerprints of Gluster's APT repo.

Note that the Gluster 5 branch uses the same PGP key for all minor releases (i.e. 5.0, 5.1, ...):
https://download.gluster.org/pub/gluster/glusterfs/5/

For verification purposes, fetched with:
curl -sL https://download.gluster.org/pub/gluster/glusterfs/$RELEASE/rsa.pub | gpg --import-options import-show --dry-run --import