### PR TITLE
Add arm64, remove i386 compatibility from ::gluster::repo:apt

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -67,14 +67,14 @@ class gluster::repo::apt (
     }
   }
 
-  # the Gluster repo only supports x86_64 and i386. armhf is only supported for Raspbian. The Ubuntu PPA also supports armhf and arm64.
+  # the Gluster repo only supports x86_64 (amd64) and arm64. The Ubuntu PPA also supports armhf and arm64.
   case $::operatingsystem {
     'Debian': {
       case $::lsbdistcodename {
         'jessie', 'stretch':  {
           $arch = $::architecture ? {
             'amd64'      => 'amd64',
-            /i\d86/      => 'i386',
+            'arm64'      => 'arm64',
             default      => false,
           }
           if versioncmp($release, '3.12') < 0 {


### PR DESCRIPTION
Looking at the glusterfs repository at
https://download.gluster.org/pub/gluster/glusterfs/, it appears
that (at least going back to 3.10):
a) arm64 packages are available
b) i386 packages are not available

Therefore, update the puppet module accordingly
