### PR TITLE
Refactor volume options fact as array

### DIFF
--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -82,7 +82,7 @@ if binary
       volume_options.each do |vol, opts|
         Facter.add("gluster_volume_#{vol}_options".to_sym) do
           setcode do
-            opts.join(',')
+            opts
           end
         end
       end

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -224,7 +224,7 @@ define gluster::volume (
       # did the options change?
       $current_options = getvar("gluster_volume_${title}_options")
       if $current_options {
-        $_current = sort( split($current_options, ',') )
+        $_current = sort($current_options)
       } else {
         $_current = []
       }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.


-->
#### Pull Request (PR) description
Volume options are stored as comma separated string, the only use from
the gluster module is in volume.pp, there it is converted back to an
array using split(). Some gluster volume options are using commas for
splitting values (e.g. auth.allow), this conflicts with this behaviour.

This change is BREAKING as it will change the output of the gluster_volume_#{vol}_options fact from a comma separated string to an actual array data type.

As the fact could be used by user implementations it should be marked in the release notes as ACTION REQUIRED.

#### This Pull Request (PR) fixes the following issues
Fixes #53 

#53 is addressing this problem and should be solved by #186. We were waiting for #186 to make progress and therefore created this minor change for ourselves.
It seems #186 is a bigger effort to achieve and also has a big impact as it will introduce major changes to the API of the module. Maybe it would be helpful to fix #53 with minor impact and then go on with the bigger effort in #186.