### PR TITLE
Support GlusterFS 6

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -38,14 +38,15 @@ class gluster::repo::apt (
   include 'apt'
 
   $repo_key_name = $release ? {
-    '3.10'       => 'C784DD0FD61E38B8B1F65E10DAD761554A72C1DF',
-    '3.11'       => 'DE82F0BACC4DB70DBEF95CA65EC2255642304A6E',
-    '3.12'       => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
-    '3.13'       => '9B5AE8E6FD2581F293104ACC38675E5F30F779AF',
-    '4.0'        => '55F839E173AC06F364120D46FA86EEACB306CEE1',
-    '4.1'        => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
-    '^5\.(\d)+$' => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
-    default      => '849512C2CA648EF425048F55C883F50CB2289A17',
+    '3.10'  => 'C784DD0FD61E38B8B1F65E10DAD761554A72C1DF',
+    '3.11'  => 'DE82F0BACC4DB70DBEF95CA65EC2255642304A6E',
+    '3.12'  => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
+    '3.13'  => '9B5AE8E6FD2581F293104ACC38675E5F30F779AF',
+    '4.0'   => '55F839E173AC06F364120D46FA86EEACB306CEE1',
+    '4.1'   => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
+    '5'     => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
+    '6'     => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
+    default => '849512C2CA648EF425048F55C883F50CB2289A17',
   }
 
   $repo_key_source = "https://download.gluster.org/pub/gluster/glusterfs/${release}/rsa.pub"
@@ -72,9 +73,9 @@ class gluster::repo::apt (
             default      => false,
           }
           if versioncmp($release, '3.12') < 0 {
-            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/LATEST/Debian/${::lsbdistcodename}/apt/"
+            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/${version}/Debian/${::lsbdistcodename}/apt/"
           } else {
-            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/LATEST/Debian/${::lsbdistcodename}/${arch}/apt/"
+            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/${version}/Debian/${::lsbdistcodename}/${arch}/apt/"
           }
         }
       }

--- a/spec/classes/repo_apt_spec.rb
+++ b/spec/classes/repo_apt_spec.rb
@@ -73,6 +73,27 @@ describe 'gluster::repo::apt', type: :class do
           end
         end
 
+        context 'Gluster release 6.3' do
+          let :params do
+            {
+              release: '6',
+              version: '6.3'
+            }
+          end
+
+          it 'installs' do
+            is_expected.to contain_apt__source('glusterfs-6.3').with(
+              repos: 'main',
+              release: facts[:lsbdistcodename].to_s,
+              key: {
+                'id' => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
+                'key_source' => 'https://download.gluster.org/pub/gluster/glusterfs/6/rsa.pub'
+              },
+              location: "https://download.gluster.org/pub/gluster/glusterfs/6/6.3/Debian/#{facts[:lsbdistcodename]}/amd64/apt/"
+            )
+          end
+        end
+
         context 'Specific Gluster release 3.12' do
           let :params do
             {


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for GlusterFS 6 on Debian.

#### This Pull Request (PR) fixes the following issues
 * Fixed release 5 support
 * Fixed using repos for minor versions e.g. [`5.4`](https://download.gluster.org/pub/gluster/glusterfs/5/5.4/):
```
release: '5'
version: '5.4'
```
should be using
* `https://download.gluster.org/pub/gluster/glusterfs/5/5.4/`
instead of 
* `https://download.gluster.org/pub/gluster/glusterfs/5/LATEST/` - `version` variable wasn't respected.