### PR TITLE
gluster volume option may be both String or Integer

### DIFF
--- a/manifests/volume/option.pp
+++ b/manifests/volume/option.pp
@@ -26,7 +26,7 @@
 # @note Copyright 2014 CoverMyMeds, unless otherwise noted
 #
 define gluster::volume::option (
-  Optional[String] $value  = undef,
+  Optional[Variant[String,Integer]] $value  = undef,
   Enum['present', 'absent'] $ensure = 'present',
 ) {
 


### PR DESCRIPTION
#### Pull Request (PR) description

This issue occurs during creation of new gluster volume. You can try to create gluster volume with these options:

```
  ::gluster::volume { $name:
  [ ...other options ommitted...]
    options => [
      "network.ping-timeout:5",
      "storage.owner-uid: 0",
      "storage.owner-gid: 0",
    ],
  }
```

It throws error that it expects String or Undef

<pre>
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Gluster::Volume::Option[data:network.ping-timeout]: parameter 'value' expects a value of type Undef or String, got Integer (file: /etc/puppetlabs/code/environments/production/modules/upstream/gluster/manifests/volume.pp, line: 266) on node gluster01.example.com
</pre>