### PR TITLE
Fix failing CI tests / switch default glusterfs version from 3.12 -> 7.3

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class gluster::params {
   # parameters dealing with installation
   $install_server = true
   $install_client = true
-  $release        = '3.12'
+  $release        = '7.3'
   $version        = 'LATEST'
 
   # we explicitly do NOT set a priority here. The user must define

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -70,6 +70,9 @@ class gluster::repo::apt (
             $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/LATEST/Debian/${::lsbdistcodename}/${arch}/apt/"
           }
         }
+        default: {
+          fail('unsupported distribution codename')
+        }
       }
     }
     default: {

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -31,14 +31,14 @@ class gluster::repo::apt (
   include 'apt'
 
   $repo_key_name = $release ? {
-    '3.10'       => 'C784DD0FD61E38B8B1F65E10DAD761554A72C1DF',
-    '3.11'       => 'DE82F0BACC4DB70DBEF95CA65EC2255642304A6E',
-    '3.12'       => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
-    '3.13'       => '9B5AE8E6FD2581F293104ACC38675E5F30F779AF',
-    '4.0'        => '55F839E173AC06F364120D46FA86EEACB306CEE1',
-    '4.1'        => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
-    '^5\.(\d)+$' => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
-    default      => '849512C2CA648EF425048F55C883F50CB2289A17',
+    '3.9'   => '849512C2CA648EF425048F55C883F50CB2289A17',
+    '3.10'  => 'C784DD0FD61E38B8B1F65E10DAD761554A72C1DF',
+    '3.11'  => 'DE82F0BACC4DB70DBEF95CA65EC2255642304A6E',
+    '3.12'  => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
+    '3.13'  => '9B5AE8E6FD2581F293104ACC38675E5F30F779AF',
+    '4.0'   => '55F839E173AC06F364120D46FA86EEACB306CEE1',
+    '4.1'   => 'EED3351AFD72E5437C050F0388F6CDEE78FA6D97',
+    default => 'F9C958A3AEE0D2184FAD1CBD43607F0DC2F8238C',
   }
 
   $repo_key_source = "https://download.gluster.org/pub/gluster/glusterfs/${release}/rsa.pub"
@@ -64,10 +64,17 @@ class gluster::repo::apt (
             'arm64'      => 'arm64',
             default      => false,
           }
-          if versioncmp($release, '3.12') < 0 {
-            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/LATEST/Debian/${::lsbdistcodename}/apt/"
+
+          $_repo_base = 'https://download.gluster.org/pub/gluster/glusterfs'
+          $repo_url = if versioncmp($release, '4.1') < 0 {
+            "${_repo_base}/01.old-releases/${release}/LATEST/Debian/${::lsbdistcodename}/${arch}/apt/"
           } else {
-            $repo_url  = "https://download.gluster.org/pub/gluster/glusterfs/${release}/LATEST/Debian/${::lsbdistcodename}/${arch}/apt/"
+            $_release = if $release == '4.1' {
+              $release
+            } else {
+              $release[0]
+            }
+            "${_repo_base}/${_release}/LATEST/Debian/${::lsbdistcodename}/${arch}/apt/"
           }
         }
         default: {

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -79,7 +79,8 @@ class gluster::repo::apt (
       fail('gluster::repo::apt currently only works on Debian')
     }
   }
-  if ! $arch {
+
+  unless $arch {
     fail("Architecture ${::architecture} not yet supported for ${::operatingsystem}.")
   }
 

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -34,10 +34,16 @@ class gluster::repo::yum (
     }
   }
 
+  $_release = if versioncmp($release, '4.1') <= 0 {
+    $release
+  } else {
+    $release[0]
+  }
+
   yumrepo { "glusterfs-${::architecture}":
     enabled  => 1,
-    baseurl  => "http://mirror.centos.org/centos/${::operatingsystemmajrelease}/storage/${::architecture}/gluster-${release}/",
-    descr    => "CentOS-${::operatingsystemmajrelease} - Gluster ${release}",
+    baseurl  => "http://mirror.centos.org/centos/${::operatingsystemmajrelease}/storage/${::architecture}/gluster-${_release}/",
+    descr    => "CentOS-${::operatingsystemmajrelease} - Gluster ${_release}",
     gpgcheck => 1,
     gpgkey   => $repo_key_source,
     priority => $priority,

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -54,10 +54,10 @@ define gluster::volume (
   Optional[Integer] $arbiter                  = undef,
 ) {
 
-  if $force {
-    $_force = 'force'
+  $_force = if $force {
+    'force'
   } else {
-    $_force = ''
+    ''
   }
 
   if $stripe {
@@ -66,10 +66,10 @@ define gluster::volume (
     $_stripe = ''
   }
 
-  if $replica {
-    $_replica = "replica ${replica}"
+  $_replica = if $replica {
+    "replica ${replica}"
   } else {
-    $_replica = ''
+    ''
   }
 
   $_transport = "transport ${transport}"

--- a/manifests/volume/option.pp
+++ b/manifests/volume/option.pp
@@ -26,8 +26,8 @@
 # @note Copyright 2014 CoverMyMeds, unless otherwise noted
 #
 define gluster::volume::option (
-  Optional[String] $value  = undef,
-  Enum['present', 'absent'] $ensure = 'present',
+  Optional[Variant[Boolean, String, Numeric]] $value  = undef,
+  Enum['present', 'absent']                   $ensure = 'present',
 ) {
 
   $arr = split( $title, ':' )
@@ -39,13 +39,22 @@ define gluster::volume::option (
   $vol = $arr[0]
   $opt = $arr[1]
 
-  if $ensure == 'absent' {
-    $cmd = "reset ${vol} ${opt}"
+  $cmd = if $ensure == 'absent' {
+    "reset ${vol} ${opt}"
   } else {
-    $cmd = "set ${vol} ${opt} ${value}"
+    "set ${vol} ${opt} ${value}"
   }
 
-  exec { "gluster option ${vol} ${opt} ${value}":
-    command => "${::gluster_binary} volume ${cmd}",
+  $_value = $value ? {
+    Boolean => if $value {
+      'on'
+    } else {
+      'off'
+    },
+    default => $value,
+  }
+
+  exec { "gluster option ${vol} ${opt} ${_value}":
+    command => "${facts['gluster_binary']} volume ${cmd}",
   }
 }

--- a/spec/classes/repo_apt_spec.rb
+++ b/spec/classes/repo_apt_spec.rb
@@ -19,7 +19,7 @@ describe 'gluster::repo::apt', type: :class do
             is_expected.to contain_apt__source('glusterfs-LATEST').with(
               repos: 'main',
               release: facts[:lsbdistcodename].to_s,
-              location: "https://download.gluster.org/pub/gluster/glusterfs/3.12/LATEST/Debian/#{facts[:lsbdistcodename]}/#{facts[:architecture]}/apt/"
+              location: "https://download.gluster.org/pub/gluster/glusterfs/7/LATEST/Debian/#{facts[:lsbdistcodename]}/#{facts[:architecture]}/apt/"
             )
           end
         end
@@ -47,7 +47,7 @@ describe 'gluster::repo::apt', type: :class do
             is_expected.to contain_apt__source('glusterfs-LATEST').with(
               repos: 'main',
               release: facts[:lsbdistcodename].to_s,
-              location: "https://download.gluster.org/pub/gluster/glusterfs/3.12/LATEST/Debian/#{facts[:lsbdistcodename]}/#{facts[:architecture]}/apt/",
+              location: "https://download.gluster.org/pub/gluster/glusterfs/7/LATEST/Debian/#{facts[:lsbdistcodename]}/#{facts[:architecture]}/apt/",
               pin: '700'
             )
           end
@@ -88,7 +88,7 @@ describe 'gluster::repo::apt', type: :class do
                 'id' => '8B7C364430B66F0B084C0B0C55339A4C6A7BD8D4',
                 'key_source' => 'https://download.gluster.org/pub/gluster/glusterfs/3.12/rsa.pub'
               },
-              location: "https://download.gluster.org/pub/gluster/glusterfs/3.12/LATEST/Debian/#{facts[:lsbdistcodename]}/amd64/apt/"
+              location: "https://download.gluster.org/pub/gluster/glusterfs/01.old-releases/3.12/LATEST/Debian/#{facts[:lsbdistcodename]}/amd64/apt/"
             )
           end
         end


### PR DESCRIPTION
This PR fixes the failing CI tests, fixes repo paths for older releases and does a bit of linting.