### PR TITLE
Use $fact to retrieve fact

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -157,12 +157,12 @@ define gluster::volume (
           require => Exec["gluster create volume ${title}"],
         }
       }
-    } elsif $already_exists {
+    } elsif $already_exists and "gluster_volume_${title}_bricks" in $facts {
       # this volume exists
 
       if $ensure == 'present' {
         # our fact lists bricks comma-separated, but we need an array
-        $vol_bricks = split( getvar( "::gluster_volume_${title}_bricks" ), ',')
+        $vol_bricks = split( $facts["gluster_volume_${title}_bricks"], ',')
         if $bricks != $vol_bricks {
           # this resource's list of bricks does not match the existing
           # volume's list of bricks


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
It will use the Puppet variable `$fact` to retrieve a fact name. Before this change, it used `getvar()` and in Puppet 6 the build-in `getvar()` is used which don't support a dash `-` in it's variable name. We had the challenge with migration to Puppet 6 this code failed because we have a volume with the name `test-vol1` (with a dash). With this change the Puppet code will build a catalog on Puppet 6. A fact may actually contain a dash and `getvar()` shouldn't be used for getting a fact variable.

#### This Pull Request (PR) fixes the following issues
Fixes #214
