### PR TITLE
Don't create notice resources when brick count does not match

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -219,9 +219,9 @@ define gluster::volume (
             }
           } elsif count($bricks) < $vol_count {
             # removing bricks
-            notify { 'removing bricks is not currently supported.': }
+            notice("removing bricks is not currently supported.\nDefined: ${_bricks}\nCurrent: ${vol_bricks}")
           } else {
-            notify { "unable to resolve brick changes for Gluster volume ${title}!\nDefined: ${_bricks}\nCurrent: ${vol_bricks}": }
+            notice("unable to resolve brick changes for Gluster volume ${title}!\nDefined: ${_bricks}\nCurrent: ${vol_bricks}")
           }
         }
 


### PR DESCRIPTION
When multiple volumes have less bricks than expected, code will fail with duplicated resource as `notify` will be declared multiple times.