### PR TITLE
Support EL8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,20 +19,11 @@ class gluster::params {
   # if they did specify a version, assume they provided a valid one
   case $facts['os']['family'] {
     'RedHat': {
-      $repo                 = true
-      $repo_gpg_key_source  = 'https://raw.githubusercontent.com/CentOS-Storage-SIG/centos-release-storage-common/master/RPM-GPG-KEY-CentOS-SIG-Storage'
-
-      $server_package = $facts['os']['release']['major'] ? {
-        # RHEL 6 and 7 provide Gluster packages natively
-        /(6|7)/ => 'glusterfs-server',
-        default => false
-      }
-      $client_package = $facts['os']['release']['major'] ? {
-        /(6|7)/ => 'glusterfs-fuse',
-        default => false,
-      }
-
-      $service_name = 'glusterd'
+      $repo                = true
+      $repo_gpg_key_source = 'https://raw.githubusercontent.com/CentOS-Storage-SIG/centos-release-storage-common/master/RPM-GPG-KEY-CentOS-SIG-Storage'
+      $server_package      = 'glusterfs-server'
+      $client_package      = 'glusterfs-fuse'
+      $service_name        = 'glusterd'
     }
     'Debian': {
       $repo           = true

--- a/metadata.json
+++ b/metadata.json
@@ -17,14 +17,16 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
This simplifies the params. It listed the same value for all supported versions and this is easier to read.

This is an alternative to https://github.com/voxpupuli/puppet-gluster/pull/207.