### PR TITLE
Add force binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   setup_matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   setup_matrix:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,2 @@
+---
+gluster::gluster_binary: '/usr/sbin/gluster'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,22 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: "osfamily/major release"
+    paths:
+    # Used to distinguish between Debian and Ubuntu
+      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
+      - "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+    # Used for Solaris
+      - "os/%{facts.os.family}/%{facts.kernelrelease}.yaml"
+  - name: "osfamily"
+    paths:
+      - "os/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"
+  - name: 'common'
+    path: 'common.yaml'
+

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -35,9 +35,9 @@
 #   peering attempt only resolves a cosmetic issue, not a functional one.
 #
 define gluster::peer (
-  $pool = 'default',
-  $fqdn = $facts['networking']['fqdn'],
-  Optional[Boolean] $force_binary = false,
+  $pool                 = 'default',
+  $fqdn                 = $facts['networking']['fqdn'],
+  Boolean $force_binary = false,
 ) {
   # we can't do much without the Gluster binary
   # but we don't necessarily want the Puppet run to fail if the

--- a/manifests/peer.pp
+++ b/manifests/peer.pp
@@ -37,11 +37,21 @@
 define gluster::peer (
   $pool = 'default',
   $fqdn = $facts['networking']['fqdn'],
+  Optional[Boolean] $force_binary = false,
 ) {
   # we can't do much without the Gluster binary
   # but we don't necessarily want the Puppet run to fail if the
   # gluster_binary fact is absent!
-  if getvar('::gluster_binary') {
+  if($force_binary) {
+    $real_binary = getvar('::gluster_binary') ? {
+      String  => getvar('::gluster_binary'),
+      default => lookup('gluster::gluster_binary',String,deep)
+    }
+  } else {
+    $real_binary = getvar('::gluster_binary')
+  }
+
+  if($real_binary) {
     # we can't join to ourselves, so it only makes sense to operate
     # on other gluster servers in the same pool
     if $fqdn != $facts['networking']['fqdn'] {
@@ -59,7 +69,7 @@ define gluster::peer (
       }
       if !$already_in_pool {
         exec { "gluster peer probe ${title}":
-          command => "${::gluster_binary} peer probe ${title}",
+          command => "${$real_binary} peer probe ${title}",
         }
       }
     }

--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -51,11 +51,11 @@ define gluster::volume (
   Boolean $rebalance                          = true,
   Boolean $heal                               = true,
   Boolean $remove_options                     = false,
+  Boolean $force_binary                       = false,
   Optional[Array] $options                    = undef,
   Optional[Integer] $stripe                   = undef,
   Optional[Integer] $replica                  = undef,
   Optional[Integer] $arbiter                  = undef,
-  Optional[Boolean] $force_binary              = false,
 ) {
   $_force = if $force {
     'force'

--- a/manifests/volume/option.pp
+++ b/manifests/volume/option.pp
@@ -26,9 +26,9 @@
 # @note Copyright 2014 CoverMyMeds, unless otherwise noted
 #
 define gluster::volume::option (
-  Optional[Variant[Boolean, String, Numeric]] $value  = undef,
-  Enum['present', 'absent']                   $ensure = 'present',
-  Optional[Boolean] $force_binary = false,
+  Optional[Variant[Boolean, String, Numeric]] $value        = undef,
+  Enum['present', 'absent']                   $ensure       = 'present',
+  Boolean                                     $force_binary = false,
 ) {
 
   if($force_binary) {

--- a/manifests/volume/option.pp
+++ b/manifests/volume/option.pp
@@ -28,7 +28,18 @@
 define gluster::volume::option (
   Optional[Variant[Boolean, String, Numeric]] $value  = undef,
   Enum['present', 'absent']                   $ensure = 'present',
+  Optional[Boolean] $force_binary = false,
 ) {
+
+  if($force_binary) {
+    $real_binary = getvar('::gluster_binary') ? {
+      String  => getvar('::gluster_binary'),
+      default => lookup('gluster::gluster_binary',String,deep)
+    }
+  } else {
+    $real_binary = getvar('::gluster_binary')
+  }
+
   $arr = split( $title, ':' )
   $count = count($arr)
   # do we have more than one array element?
@@ -54,6 +65,6 @@ define gluster::volume::option (
   }
 
   exec { "gluster option ${vol} ${opt} ${_value}":
-    command => "${facts['gluster_binary']} volume ${cmd}",
+    command => "${real_binary} volume ${cmd}",
   }
 }

--- a/manifests/volume/option.pp
+++ b/manifests/volume/option.pp
@@ -30,7 +30,6 @@ define gluster::volume::option (
   Enum['present', 'absent']                   $ensure       = 'present',
   Boolean                                     $force_binary = false,
 ) {
-
   if($force_binary) {
     $real_binary = getvar('::gluster_binary') ? {
       String  => getvar('::gluster_binary'),

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
+        "9"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,6 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9",
-        "10"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -16,21 +16,20 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -5,7 +5,8 @@ describe 'gluster::peer', type: :define do
 
   let(:params) do
     {
-      fqdn: 'peer1.example.com'
+      fqdn: 'peer1.example.com',
+      force_binary: 'true'
     }
   end
 

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -6,7 +6,7 @@ describe 'gluster::peer', type: :define do
   let(:params) do
     {
       fqdn: 'peer1.example.com',
-      force_binary: 'true'
+      force_binary: true
     }
   end
 

--- a/spec/defines/peer_spec.rb
+++ b/spec/defines/peer_spec.rb
@@ -6,7 +6,7 @@ describe 'gluster::peer', type: :define do
   let(:params) do
     {
       fqdn: 'peer1.example.com',
-      force_binary: true
+      force_binary: false
     }
   end
 

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -14,7 +14,8 @@ describe 'gluster::volume', type: :define do
       options: [
         'server.allow-insecure: on',
         'nfs.ports-insecure: on'
-      ]
+      ],
+      force_binary: true,
     }
   end
 


### PR DESCRIPTION
needed if we've to deploy the whole gluster server in one Run.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
We needed the posibility to deploy the glusterfs-server at the first run, this won't work actually. So I've added the variable to force the binary path and disables the getvar() for the first run. With this we are able to add the Peers and Volume at the first run.

#### This Pull Request (PR) fixes the following issues
n/a