### PR TITLE
remove apt repo for ubuntu 22.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,11 @@ class gluster::params {
       $service_name = 'glusterd'
     }
     'Debian': {
-      $repo           = true
+      # Ubuntu 22.04 includes GlusterFS in the base repositories
+      $repo = "${facts['os']['name']}_${facts['os']['release']['major']}" ? {
+        'Ubuntu_22.04' => false,
+        default => true
+      }
       $server_package = 'glusterfs-server'
       $client_package = 'glusterfs-client'
       $service_name   = 'glusterd'

--- a/metadata.json
+++ b/metadata.json
@@ -43,8 +43,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     }
   ],

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -64,7 +64,7 @@ describe 'gluster::client', type: :class do
             client_package: 'glusterfs-client',
             version: 'LATEST'
           }
-          repo_params[:repo] = 'ubuntu-22.04-x86_64'.eql?(os)
+          repo_params[:repo] = !'ubuntu-22.04-x86_64'.eql?(os)
 
           it 'includes gluster::install' do
             is_expected.to create_class('gluster::install').with(repo_params)

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -60,13 +60,18 @@ describe 'gluster::client', type: :class do
           it { is_expected.to contain_class('gluster::client') }
           it { is_expected.to compile.with_all_deps }
 
-          it 'includes gluster::install' do
-            is_expected.to create_class('gluster::install').with(
-              repo: true,
-              client_package: 'glusterfs-client',
-              version: 'LATEST'
-            )
+          repo_params = {
+            client_package: 'glusterfs-client',
+            version: 'LATEST'
+          }
+          if os == 'ubuntu-22.04-x86_64'
+            repo_params[:repo] = false
+          else
+            repo_params[:repo] = true
           end
+          it 'includes gluster::install' do
+            is_expected.to create_class('gluster::install').with(repo_params)
+           end
         end
 
         context 'when a version number is specified' do

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -64,14 +64,11 @@ describe 'gluster::client', type: :class do
             client_package: 'glusterfs-client',
             version: 'LATEST'
           }
-          if os == 'ubuntu-22.04-x86_64'
-            repo_params[:repo] = false
-          else
-            repo_params[:repo] = true
-          end
+          repo_params[:repo] = 'ubuntu-22.04-x86_64'.eql?(os)
+
           it 'includes gluster::install' do
             is_expected.to create_class('gluster::install').with(repo_params)
-           end
+          end
         end
 
         context 'when a version number is specified' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,7 +13,7 @@ describe 'gluster', type: :class do
         it { is_expected.to contain_class('gluster') }
         it { is_expected.to contain_class('gluster::params') }
 
-        it { is_expected.to contain_class('gluster::repo') } unless facts[:os]['family'] == 'Archlinux' || facts[:os]['family'] == 'Suse'
+        it { is_expected.to contain_class('gluster::repo') } unless facts[:os]['family'] == 'Archlinux' || facts[:os]['family'] == 'Suse' || os == 'ubuntu-22.04-x86_64'
         it { is_expected.to compile.with_all_deps }
 
         it 'includes classes' do
@@ -73,18 +73,24 @@ describe 'gluster', type: :class do
         end
       when 'Debian'
         context 'Debian specific stuff' do
-          it { is_expected.to contain_class('gluster::repo::apt') }
-          it { is_expected.to contain_apt__source('glusterfs-LATEST') }
+          it { is_expected.to contain_class('gluster::repo::apt') } unless os == 'ubuntu-22.04-x86_64'
+          it { is_expected.to contain_apt__source('glusterfs-LATEST') } unless os == 'ubuntu-22.04-x86_64'
+
+          repo_params = {
+            server: true,
+            server_package: 'glusterfs-server',
+            client: true,
+            client_package: 'glusterfs-client',
+            version: 'LATEST',
+          }
+          if os == 'ubuntu-22.04-x86_64'
+            repo_params[:repo] = false
+          else
+            repo_params[:repo] = true
+          end
 
           it 'creates gluster::install' do
-            is_expected.to create_class('gluster::install').with(
-              server: true,
-              server_package: 'glusterfs-server',
-              client: true,
-              client_package: 'glusterfs-client',
-              version: 'LATEST',
-              repo: true
-            )
+            is_expected.to create_class('gluster::install').with(repo_params)
           end
         end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -83,7 +83,7 @@ describe 'gluster', type: :class do
             client_package: 'glusterfs-client',
             version: 'LATEST',
           }
-          repo_params[:repo] = 'ubuntu-22.04-x86_64'.eql?(os)
+          repo_params[:repo] = !'ubuntu-22.04-x86_64'.eql?(os)
 
           it 'creates gluster::install' do
             is_expected.to create_class('gluster::install').with(repo_params)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -83,11 +83,7 @@ describe 'gluster', type: :class do
             client_package: 'glusterfs-client',
             version: 'LATEST',
           }
-          if os == 'ubuntu-22.04-x86_64'
-            repo_params[:repo] = false
-          else
-            repo_params[:repo] = true
-          end
+          repo_params[:repo] = 'ubuntu-22.04-x86_64'.eql?(os)
 
           it 'creates gluster::install' do
             is_expected.to create_class('gluster::install').with(repo_params)

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -24,7 +24,7 @@ describe 'gluster::install', type: :class do
         when 'Debian'
           it { is_expected.to create_package('glusterfs-server') }
           it { is_expected.to create_package('glusterfs-client') }
-          it { is_expected.to create_class('gluster::repo').with(version: 'LATEST') }
+          it { is_expected.to create_class('gluster::repo').with(version: 'LATEST') } unless os == 'ubuntu-22.04-x86_64'
           # rubocop:enable RSpec/RepeatedExample
         end
       end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -74,7 +74,7 @@ describe 'gluster::install', type: :class do
         when 'Archlinux', 'Suse'
           it { is_expected.not_to create_class('gluster::repo') }
         else
-          it { is_expected.to compile.and_raise_error(%r{not yet supported}) }
+          it { is_expected.to compile.and_raise_error(%r{not yet supported}) } unless os == 'ubuntu-22.04-x86_64'
         end
       end
     end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -24,6 +24,7 @@ describe 'gluster::install', type: :class do
         when 'Debian'
           it { is_expected.to create_package('glusterfs-server') }
           it { is_expected.to create_package('glusterfs-client') }
+
           it { is_expected.to create_class('gluster::repo').with(version: 'LATEST') } unless os == 'ubuntu-22.04-x86_64'
           # rubocop:enable RSpec/RepeatedExample
         end

--- a/spec/classes/repo_apt_spec.rb
+++ b/spec/classes/repo_apt_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'gluster::repo::apt', type: :class do
   on_supported_os.each do |os, os_facts|
     # Ubuntu 22.04 does not require a repo
-    context "on #{os}", if: os_facts[:os]['family'] == 'Debian' and os_facts[:os]['release']['major'] != '22.04' do
+    context "on #{os}", if: os_facts[:os]['family'] == 'Debian' && os_facts[:os]['release']['major'] != '22.04' do
       let(:facts) { os_facts }
       let(:pre_condition) { 'require gluster::params' }
 

--- a/spec/classes/repo_apt_spec.rb
+++ b/spec/classes/repo_apt_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 
 describe 'gluster::repo::apt', type: :class do
   on_supported_os.each do |os, os_facts|
-    context "on #{os}", if: os_facts[:os]['family'] == 'Debian' do
+    # Ubuntu 22.04 does not require a repo
+    context "on #{os}", if: os_facts[:os]['family'] == 'Debian' and os_facts[:os]['release']['major'] != '22.04' do
       let(:facts) { os_facts }
       let(:pre_condition) { 'require gluster::params' }
 


### PR DESCRIPTION
#### Pull Request (PR) description

set apt repo to false and skip unit test for the repo on Ubuntu 22.04

#### This Pull Request (PR) fixes the following issues

Ubuntu 22.04 includes Gluster in the base repositories