### PR TITLE
If the sequence in facts and settings is different

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -163,7 +163,7 @@ define gluster::volume (
       if $ensure == 'present' {
         # our fact lists bricks comma-separated, but we need an array
         $vol_bricks = split( $facts["gluster_volume_${title}_bricks"], ',')
-        if $bricks != $vol_bricks {
+        if $bricks.sort != $vol_bricks.sort {
           # this resource's list of bricks does not match the existing
           # volume's list of bricks
           $new_bricks = difference($bricks, $vol_bricks)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
If the sequence in facts and settings is different exampe:
[ 'gst02:/opt/share', 'gst03:/opt/share', 'gst01:/opt/share'] != [ 'gst01:/opt/share', 'gst02:/opt/share', 'gst03:/opt/share'] 
but in fact they are equal

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
