### PR TITLE
If the peer name in the facts is not the same as in the configuration

### DIFF
--- a/lib/facter/gluster.rb
+++ b/lib/facter/gluster.rb
@@ -8,6 +8,7 @@ gluster_peers = {}
 gluster_volumes = {}
 peer_count = 0
 peer_list = ''
+peer_list_ar = []
 volume_options = {}
 volume_ports = {}
 
@@ -50,9 +51,14 @@ if binary
     gluster_peers[peer]['status'] = peer_xml.elements['stateStr'].text.to_s
   end
 
+  # Collecting all hostnames of peers
+  REXML::XPath.match(peer_status_xml, '/cliOutput/peerStatus/peer/hostnames/hostname').each do |hn|
+    peer_list_ar.append(hn.to_a)
+  end
+
   # Extract and format the data needed for the legacy peer facts.
   peer_count = gluster_peers.size
-  peer_list = gluster_peers.keys.join(',')
+  peer_list = peer_list_ar.join(',')
 
   # Get our volume information from gluster volume info
   volume_info_xml = REXML::Document.new(Facter::Util::Resolution.exec("#{binary} volume info --xml"))


### PR DESCRIPTION
#### Pull Request (PR) description
If the peer name in the facts is not the same as in the configuration: #gluster peer status --xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?> <cliOutput>
.........
  <peerStatus>
    <peer>
.........
      <hostname>192.168.0.10</hostname>
      <hostnames>
        <hostname>192.68.0.10</hostname>
        <hostname>gst03</hostname>
      </hostnames>
..........
    </peer>
    <peer>
.........
      <hostname>gst02</hostname>
      <hostnames>
        <hostname>gst02</hostname>
      </hostnames>
.........
    </peer>
  </peerStatus>
</cliOutput>
Then the gluster_peer_list fact will contain the following line: 192.168.0.10,gst02
and due to the fact that the configuration says gst03 and not IP, the following will always be executed: Notice: /Stage[main]/myclass /Gluster::Peer[gst03]/Exec[gluster peer probe gst03]/returns: executed successfully (corrective) My edit takes all names from peers /cliOutput/peerStatus/peer/hostnames/hostname the fact string will be:
192.168.0.10,gst03,gst02
and then in line 52 of the manifests/peer.pp file it will find the value. After this, the command "gluster peer probe gst03" will not be executed every time


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
