### PR TITLE
fix: compilation error when `gluster::volume` options are not set

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -240,10 +240,15 @@ define gluster::volume (
           } else {
             if $_current =~ Array {
               # $_options is not an array, so remove all currently set options
+              $to_add = undef
               $to_remove = $_current
             } elsif $_options =~ Array {
               # $current_options is not an array, so add all our defined options
               $to_add = $_options
+              $to_remove = undef
+            } else {
+              $to_add = undef
+              $to_remove = undef
             }
           }
           if ! empty($to_remove) {

--- a/spec/defines/volume_spec.rb
+++ b/spec/defines/volume_spec.rb
@@ -100,6 +100,29 @@ describe 'gluster::volume', type: :define do
     end
   end
 
+  describe 'with existent volume' do
+    let(:title)  { 'volume1' }
+    let(:facts) do
+      {
+        gluster_binary: '/usr/sbin/gluster',
+        gluster_peer_list: 'srv1.local,srv2.local',
+        gluster_volume_list: 'volume1',
+        gluster_volume_volume1_bricks: 'srv1.local:/export/volume1/brick,srv2.local:/export/volume1/brick',
+      }
+    end
+    let(:params) do
+      {
+        replica: 2,
+        bricks: [
+          'srv1.local:/export/volume1/brick',
+          'srv2.local:/export/volume1/brick',
+        ],
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+  end
+
   describe 'single node' do
     let(:facts) do
       {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This is a rebased version of https://github.com/voxpupuli/puppet-gluster/pull/264

- Add failing test for gluster::volume
- Fix unknown variable error

<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
